### PR TITLE
Light/Darkmode Bug gefixt

### DIFF
--- a/static/css/global.css
+++ b/static/css/global.css
@@ -1,11 +1,6 @@
-<<<<<<< Updated upstream
 body.light-mode {
     background-color: #ffffff;
     color: #333333;
-=======
-html {
-    font-family: Arial, Helvetica, sans-serif;
->>>>>>> Stashed changes
 }
 body.dark-mode {
     background-color: #1a1a1a;

--- a/static/js/theme-toggle.js
+++ b/static/js/theme-toggle.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
     const toggleButton = document.getElementById('theme-toggle');
     let currentTheme = localStorage.getItem('theme') || 'light-mode';
+    console.debug(currentTheme);
     document.body.className = currentTheme;
     updateButtonText();
     toggleButton.addEventListener('click', function() {


### PR DESCRIPTION
In diesem Commit wurde eine Änderung im CSS Code rückgängig gemacht, die dazu führte, dass der Light/Darkmode Umschalter nicht mehr funktionierte, weil entsprechende CSS Klassen nicht mehr auffindbar waren.